### PR TITLE
Do less evasion move validation

### DIFF
--- a/src/main/java/game/Board.java
+++ b/src/main/java/game/Board.java
@@ -261,15 +261,15 @@ final class Board {
         long checkers = attacksTo(king, !this.turn);
 
         if (checkers == 0) {
+            hasEp = genEnPassant(moves);
             long target = ~us();
             genNonKing(target, moves);
             genSafeKing(king, target, moves);
             genCastling(king, moves);
-            hasEp = genEnPassant(moves);
         } else {
+            hasEp = (checkers & this.pawns) != 0 && genEnPassant(moves);
             // May generate illegal check-blocking moves.
             genEvasions(king, checkers, moves);
-            hasEp = (checkers & this.pawns) != 0 && genEnPassant(moves);
         }
 
         long blockers = sliderBlockers(king);

--- a/src/main/java/game/Board.java
+++ b/src/main/java/game/Board.java
@@ -261,15 +261,15 @@ final class Board {
         long checkers = attacksTo(king, !this.turn);
 
         if (checkers == 0) {
-            hasEp = genEnPassant(moves);
             long target = ~us();
             genNonKing(target, moves);
             genSafeKing(king, target, moves);
             genCastling(king, moves);
+            hasEp = genEnPassant(moves);
         } else {
-            hasEp = (checkers & this.pawns) != 0 && genEnPassant(moves);
             // May generate illegal check-blocking moves.
             genEvasions(king, checkers, moves);
+            hasEp = (checkers & this.pawns) != 0 && genEnPassant(moves);
         }
 
         long blockers = sliderBlockers(king);

--- a/src/main/java/game/Board.java
+++ b/src/main/java/game/Board.java
@@ -256,7 +256,7 @@ final class Board {
         moves.clear();
 
         int king = king(this.turn);
-        boolean hasEp = false;
+        boolean hasEp;
 
         long checkers = attacksTo(king, !this.turn);
 
@@ -269,9 +269,7 @@ final class Board {
         } else {
             // May generate illegal check-blocking moves.
             genEvasions(king, checkers, moves);
-            if (this.epSquare != 0 && (checkers & this.pawns) != 0) {
-                hasEp = genEnPassant(moves);
-            }
+            hasEp = (checkers & this.pawns) != 0 && genEnPassant(moves);
         }
 
         long blockers = sliderBlockers(king);


### PR DESCRIPTION
`isSafe` incurs a cost, so only call it when there is a pinned piece, or an en passant move (which removes two pawns from the same rank, and perhaps the king is on the same rank).

Also when generating evasions, only generate en passant if in check by a pawn.