### PR TITLE
Fast en passant

### DIFF
--- a/src/main/java/game/Board.java
+++ b/src/main/java/game/Board.java
@@ -163,9 +163,12 @@ final class Board {
         switch (move.type) {
             case Move.NORMAL:
                 if (move.role == Role.PAWN && Math.abs(move.from - move.to) == 16) {
-                    int sq = move.from + (this.turn ? 8 : -8);
-                    if ((Bitboard.pawnAttacks(this.turn, sq) & this.pawns & them()) != 0) {
-                        this.epSquare = sq;
+                    long theirPawns = them() & this.pawns;
+                    if (theirPawns != 0) {
+                        int sq = move.from + (this.turn ? 8 : -8);
+                        if ((Bitboard.pawnAttacks(this.turn, sq) & theirPawns) != 0) {
+                            this.epSquare = sq;
+                        }
                     }
                 }
 

--- a/src/main/java/game/Board.java
+++ b/src/main/java/game/Board.java
@@ -259,9 +259,11 @@ final class Board {
     public void legalMoves(MoveList moves) {
         moves.clear();
 
-        int king = king(this.turn);
-        boolean hasEp = genEnPassant(moves);
+        if (this.epSquare != 0) {
+            genEnPassant(moves);
+        }
 
+        int king = king(this.turn);
         long checkers = attacksTo(king, !this.turn);
         if (checkers == 0) {
             long target = ~us();
@@ -273,7 +275,7 @@ final class Board {
         }
 
         long blockers = sliderBlockers(king);
-        if (blockers != 0 || hasEp) {
+        if (blockers != 0 || this.epSquare != 0) {
             moves.retain(m -> isSafe(king, m, blockers));
         }
     }
@@ -285,7 +287,7 @@ final class Board {
         if (this.epSquare == 0) return false; // shortcut
 
         MoveList moves = new MoveList(2);
-        if (! genEnPassant(moves)) return false; // shortcut
+        genEnPassant(moves);
 
         int king = king(this.turn);
         long blockers = sliderBlockers(king);
@@ -434,18 +436,13 @@ final class Board {
         }
     }
 
-    private boolean genEnPassant(MoveList moves) {
-        if (this.epSquare == 0) return false;
-
-        boolean found = false;
+    private void genEnPassant(MoveList moves) {
         long pawns = us() & this.pawns & Bitboard.pawnAttacks(!this.turn, this.epSquare);
         while (pawns != 0) {
             int pawn = Bitboard.lsb(pawns);
             moves.pushEnPassant(this, pawn, this.epSquare);
-            found = true;
             pawns &= pawns - 1;
         }
-        return found;
     }
 
     private void genCastling(int king, MoveList moves) {

--- a/src/main/java/game/Board.java
+++ b/src/main/java/game/Board.java
@@ -163,7 +163,10 @@ final class Board {
         switch (move.type) {
             case Move.NORMAL:
                 if (move.role == Role.PAWN && Math.abs(move.from - move.to) == 16) {
-                    this.epSquare = move.from + (this.turn ? 8 : -8);
+                    int sq = move.from + (this.turn ? 8 : -8);
+                    if ((Bitboard.pawnAttacks(this.turn, sq) & this.pawns & them()) != 0) {
+                        this.epSquare = sq;
+                    }
                 }
 
                 if (this.castlingRights != 0) {
@@ -282,15 +285,11 @@ final class Board {
         if (this.epSquare == 0) return false; // shortcut
 
         MoveList moves = new MoveList(2);
-        boolean hasEp = genEnPassant(moves);
+        if (! genEnPassant(moves)) return false; // shortcut
 
-        if (hasEp) {
-            int king = king(this.turn);
-            long blockers = sliderBlockers(king);
-            return moves.anyMatch(m -> isSafe(king, m, blockers));
-        }
-
-        return false;
+        int king = king(this.turn);
+        long blockers = sliderBlockers(king);
+        return moves.anyMatch(m -> isSafe(king, m, blockers));
     }
 
     private void genNonKing(long mask, MoveList moves) {


### PR DESCRIPTION
This shifts the cost of pseudo-validating the en passant square (that it is attacked by a pawn) from `hasLegalEnPassant` (a cost later repeated in `legalMoves`) into `play`.

In most cases after a pawn double-push the en passant square is not attacked by a pawn, so entire function calls (to `genEnPassant`) can be skipped.

Master:

```
[info] Result "org.lichess.compression.game.HuffmanPgnPerf.encodeAndDecode":
[info]   35310.107 ±(99.9%) 136.402 us/op [Average]
[info]   (min, avg, max) = (34966.302, 35310.107, 37651.676), stdev = 402.185
[info]   CI (99.9%): [35173.705, 35446.509] (assumes normal distribution)
[info] # Run complete. Total time: 00:02:40
[info] Benchmark                       Mode  Cnt      Score     Error  Units
[info] HuffmanPgnPerf.encodeAndDecode  avgt  100  35310.107 ± 136.402  us/op
```

Patch minus last commit (0.06% speedup):

```
[info] Result "org.lichess.compression.game.HuffmanPgnPerf.encodeAndDecode":
[info]   35286.118 ±(99.9%) 66.687 us/op [Average]
[info]   (min, avg, max) = (35021.479, 35286.118, 36022.371), stdev = 196.628
[info]   CI (99.9%): [35219.431, 35352.805] (assumes normal distribution)
[info] # Run complete. Total time: 00:02:40
[info] Benchmark                       Mode  Cnt      Score    Error  Units
[info] HuffmanPgnPerf.encodeAndDecode  avgt  100  35286.118 ± 66.687  us/op
```

Patched including short-circuit evaluation last commit (0.22% speedup):

```
[info] Result "org.lichess.compression.game.HuffmanPgnPerf.encodeAndDecode":
[info]   35232.646 ±(99.9%) 86.511 us/op [Average]
[info]   (min, avg, max) = (34610.603, 35232.646, 36113.221), stdev = 255.079
[info]   CI (99.9%): [35146.135, 35319.157] (assumes normal distribution)
[info] # Run complete. Total time: 00:02:40
[info] Benchmark                       Mode  Cnt      Score    Error  Units
[info] HuffmanPgnPerf.encodeAndDecode  avgt  100  35232.646 ± 86.511  us/op
```