### PR TITLE
docs: replace dead magic bitboard link with wikipedia

### DIFF
--- a/src/main/java/game/Magic.java
+++ b/src/main/java/game/Magic.java
@@ -17,7 +17,7 @@ class Magic {
     }
 
     // Precomputed overlapping fixed shift magics:
-    // https://en.wikipedia.org/wiki/Bitboard#Magic_bitboards
+    //  https://www.chessprogramming.org/Magic_Bitboards
 
     public static Magic ROOK[] = {
         new Magic(0x000101010101017eL, 0x00280077ffebfffeL, 26304),

--- a/src/main/java/game/Magic.java
+++ b/src/main/java/game/Magic.java
@@ -17,7 +17,7 @@ class Magic {
     }
 
     // Precomputed overlapping fixed shift magics:
-    //  https://www.chessprogramming.org/Magic_Bitboards
+    // https://www.chessprogramming.org/Magic_Bitboards#Fixed_shift_Fancy
 
     public static Magic ROOK[] = {
         new Magic(0x000101010101017eL, 0x00280077ffebfffeL, 26304),

--- a/src/main/java/game/Magic.java
+++ b/src/main/java/game/Magic.java
@@ -17,7 +17,7 @@ class Magic {
     }
 
     // Precomputed overlapping fixed shift magics:
-    // https://chessprogramming.wikispaces.com/Magic+Bitboards#FixedShiftFancy
+    // https://en.wikipedia.org/wiki/Bitboard#Magic_bitboards
 
     public static Magic ROOK[] = {
         new Magic(0x000101010101017eL, 0x00280077ffebfffeL, 26304),


### PR DESCRIPTION
Great work in Lichess. Was looking through the code out of interest and noticed a dead link so here's a fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lichess-org/compression/7)
<!-- Reviewable:end -->
