### PR TITLE
rank moves without sorting the entire list

### DIFF
--- a/src/main/scala/game/Board.scala
+++ b/src/main/scala/game/Board.scala
@@ -189,7 +189,7 @@ final class Board(
 
       val king     = getKing(this.turn)
       val blockers = sliderBlockers(king)
-      moves.anyMatch(m => isSafe(king, m, blockers))
+      moves.exists(m => isSafe(king, m, blockers))
 
   private def genNonKing(mask: Long, moves: MoveList): Unit =
     genPawn(mask, moves)

--- a/src/main/scala/game/Encoder.scala
+++ b/src/main/scala/game/Encoder.scala
@@ -52,21 +52,12 @@ object Encoder:
             if matcher.group(5) != null then promotion = charToRole(matcher.group(5).charAt(0))
 
       board.legalMoves(legals)
-      legals.sort()
-      var foundMatch = false
-      for i <- 0 until legals.getSize() do
-        val legal = legals.get(i)
-        if legal.role == role && legal.to == to && legal.promotion == promotion && Bitboard.contains(
-            from,
-            legal.from
-          )
-        then
-          if foundMatch then return null
-          Huffman.write(i, writer)
-          board.play(legal)
-          foundMatch = true
-
-      if !foundMatch then return null
+      legals.find(legal => legal.role == role && legal.to == to && legal.promotion == promotion && Bitboard.contains(from, legal.from)) match
+        case None =>
+          return null
+        case Some(move) =>
+          Huffman.write(legals.rank(move), writer)
+          board.play(move)
 
     writer.toArray()
   end encode

--- a/src/main/scala/game/MoveList.scala
+++ b/src/main/scala/game/MoveList.scala
@@ -37,7 +37,7 @@ final class MoveList(capacity: Int = 256):
     buffer.view.take(size).exists(predicate)
 
   def rank(move: Move): Int =
-    buffer.view.take(size).count(m => m < move)
+    buffer.view.take(size).count(_ < move)
 
   def retain(predicate: Move => Boolean): Unit =
     var i = 0

--- a/src/main/scala/game/MoveList.scala
+++ b/src/main/scala/game/MoveList.scala
@@ -30,10 +30,14 @@ final class MoveList(capacity: Int = 256):
     buffer(size).set(board, Move.EN_PASSANT, Role.PAWN, capturer, true, to, null)
     size += 1
 
-  // Cast is needed because scala arrays are not covariant.
-  def sort(): Unit = java.util.Arrays.sort(buffer.asInstanceOf[Array[Object]], 0, size)
+  def find(predicate: Move => Boolean): Option[Move] =
+    buffer.view.take(size).find(predicate)
 
-  def anyMatch(predicate: Move => Boolean): Boolean = buffer.take(size).exists(predicate)
+  def exists(predicate: Move => Boolean): Boolean =
+    buffer.view.take(size).exists(predicate)
+
+  def rank(move: Move): Int =
+    buffer.view.take(size).count(m => m < move)
 
   def retain(predicate: Move => Boolean): Unit =
     var i = 0


### PR DESCRIPTION
Before:

    [info] Benchmark               Mode  Cnt     Score    Error  Units
    [info] HuffmanPgnBench.encode  avgt  120  7181.847 ± 48.616  us/op

After:

    [info] HuffmanPgnBench.encode  avgt  120  3126.608 ± 19.164  us/op